### PR TITLE
Add prefix to certificate secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add prefix to certificate secret to prevent conflict with other certificates.
+
 ## [0.1.2] - 2022-06-30
 
 ### Fixed

--- a/helm/cluster-api-provider-cloud-director/templates/certificate.yaml
+++ b/helm/cluster-api-provider-cloud-director/templates/certificate.yaml
@@ -13,4 +13,4 @@ spec:
   issuerRef:
     kind: Issuer
     name: capvcd-selfsigned-issuer # <= FILECHECK: SHOULD WE USE selfsigned-giantswarm?
-  secretName: webhook-server-cert
+  secretName: capvcd-webhook-server-cert

--- a/helm/cluster-api-provider-cloud-director/templates/deployment.yaml
+++ b/helm/cluster-api-provider-cloud-director/templates/deployment.yaml
@@ -65,7 +65,7 @@ spec:
       - name: cert
         secret:
           defaultMode: 420
-          secretName: webhook-server-cert
+          secretName: capvcd-webhook-server-cert
       - configMap:
           name: capvcd-manager-config
         name: controller-manager-config-volume


### PR DESCRIPTION
The webhook-server-cert is used by other certificates. See https://github.com/giantswarm/management-cluster-admission/blob/main/helm/management-cluster-admission/templates/kustomize-out.yaml#L445

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
