### PR TITLE
Workaround to fix cpi and csi in cloud-init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Built controller image from upstream commit `8a5e8da` with fix to cloud-init.
+- Fixes cloud-init trying to pull CPI and CSI images from the wrong repos (main branch).
+
 ## [0.2.0] - 2022-08-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -7,15 +7,21 @@
 The image is currently built manually from a specific commit since the only release is outdated and `main` is the development branch. The capvcd helm chart is based on the output of `kustomize build` in the following folder:
 
 * Repo: https://github.com/vmware/cluster-api-provider-cloud-director/tree/main/config/default
-* Commit: befab0a48bd8ca8b1dde7c92e3f89dfc137c4638
+* Commit: `8a5e8da3676d51f4bbf0ba2900fab96443c8eb96`
+
+This build includes a fix for https://github.com/giantswarm/giantswarm/issues/23085#issuecomment-1209339260.
+
+The fix was to hardcode the [CPI](https://github.com/vmware/cluster-api-provider-cloud-director/blob/main/controllers/cluster_scripts/cloud_init.tmpl#L123) and [CSI](https://github.com/vmware/cluster-api-provider-cloud-director/blob/main/controllers/cluster_scripts/cloud_init.tmpl#L138) versions in the cloud-init script, otherwise it uses the repos from main for both, which point to an internal VMware repo we don't have access to.
+
+This is temporary workaround, future commits will move CPI and CSI to Cluster Resource Sets that we can then ignore in favor of our own `cloud-provider-cloud-director` app.
 
 ## How to use
 
 There are no credentials in the CAPVCD controller. The credentials are stored in a secret in a namespace that is referenced in the cluster chart.
 
-* Install cluster API v1.1.3.
+* Install cluster API v1.1.5.
 
-`clusterctl init --core cluster-api:v1.1.3 -b kubeadm:v1.1.3 -c kubeadm:v1.1.3`
+`clusterctl init --core cluster-api:v1.1.5 -b kubeadm:v1.1.5 -c kubeadm:v1.1.5`
 
 __The vipSubnet field has been moved to the VCDCluster CRD in [cluster-cloud-director](https://github.com/vmware/cluster-api-provider-cloud-director).__
 

--- a/helm/cluster-api-provider-cloud-director/values.yaml
+++ b/helm/cluster-api-provider-cloud-director/values.yaml
@@ -1,6 +1,6 @@
 image:
   name: quay.io/giantswarm/cluster-api-provider-cloud-director-vcd
-  tag: befab0a
+  tag: 8a5e8da
 
 project:
   branch: ""


### PR DESCRIPTION
This PR:

- Adds a workaround to force cloud-init to download CPI and CSI images from release tags instead of main branches.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
