### PR TITLE
Add switch for no rde

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Built controller image from upstream commit `0fa7fa9` with fix to cloud-init.
+- New build includes new `skipRDE` switch which include `RdeID` to `VCDCluster` when __NO_RDE__ is used to fix `clusterctl move`.
+
 ## [0.2.1] - 2022-08-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -9,11 +9,7 @@ The image is currently built manually from a specific commit since the only rele
 * Repo: https://github.com/vmware/cluster-api-provider-cloud-director/tree/main/config/default
 * Commit: `8a5e8da3676d51f4bbf0ba2900fab96443c8eb96`
 
-This build includes a fix for https://github.com/giantswarm/giantswarm/issues/23085#issuecomment-1209339260.
-
-The fix was to hardcode the [CPI](https://github.com/vmware/cluster-api-provider-cloud-director/blob/main/controllers/cluster_scripts/cloud_init.tmpl#L123) and [CSI](https://github.com/vmware/cluster-api-provider-cloud-director/blob/main/controllers/cluster_scripts/cloud_init.tmpl#L138) versions in the cloud-init script, otherwise it uses the repos from main for both, which point to an internal VMware repo we don't have access to.
-
-This is temporary workaround, future commits will move CPI and CSI to Cluster Resource Sets that we can then ignore in favor of our own `cloud-provider-cloud-director` app.
+This build includes a fix for https://github.com/giantswarm/giantswarm/issues/23085#issuecomment-1209339260. Hardcode the [CPI](https://github.com/vmware/cluster-api-provider-cloud-director/blob/main/controllers/cluster_scripts/cloud_init.tmpl#L123) and [CSI](https://github.com/vmware/cluster-api-provider-cloud-director/blob/main/controllers/cluster_scripts/cloud_init.tmpl#L138) versions in the cloud-init script, otherwise it uses the repos from main for both, which point to an internal VMware repo we don't have access to. This is temporary workaround, future commits will move CPI and CSI to Cluster Resource Sets that we can then ignore in favor of our own `cloud-provider-cloud-director` app.
 
 ## How to use
 
@@ -22,7 +18,5 @@ There are no credentials in the CAPVCD controller. The credentials are stored in
 * Install cluster API v1.1.5.
 
 `clusterctl init --core cluster-api:v1.1.5 -b kubeadm:v1.1.5 -c kubeadm:v1.1.5`
-
-__The vipSubnet field has been moved to the VCDCluster CRD in [cluster-cloud-director](https://github.com/vmware/cluster-api-provider-cloud-director).__
 
 * Install the chart with the values file.

--- a/helm/cluster-api-provider-cloud-director/files/vcdclusters.yaml
+++ b/helm/cluster-api-provider-cloud-director/files/vcdclusters.yaml
@@ -237,6 +237,11 @@ spec:
                 type: string
               site:
                 type: string
+              skipRDE:
+                default: false
+                description: SkipRDE tells CAPVCD if an RDE should be created for
+                  the cluster or not
+                type: boolean
               useAsManagementCluster:
                 type: boolean
               userContext:

--- a/helm/cluster-api-provider-cloud-director/values.yaml
+++ b/helm/cluster-api-provider-cloud-director/values.yaml
@@ -1,6 +1,6 @@
 image:
   name: quay.io/giantswarm/cluster-api-provider-cloud-director-vcd
-  tag: 8a5e8da
+  tag: 0fa7fa9
 
 project:
   branch: ""


### PR DESCRIPTION
This PR:

- adds support for the new `skipRDE `switch which adds the `RdeID `to the `VCDCluster `spec to fix an issue in `clusterctl move` where it would generate a new ID and try to create a new load balancer.

### Testing

- Tested using a cluster-cloud-director version that includes the changes.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
