### PR TITLE
Consume clusterctl move fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Consume `5436e90` from `giantswarm` fork to bring `clusterctl move` fix.
+
 ## [0.2.5] - 2022-11-15
 
 ### Added

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -5,7 +5,7 @@ SHELL := /bin/bash
 APPLICATION_NAME="cluster-api-provider-cloud-director"
 
 UPSTREAM_ORG="giantswarm"
-COMMIT_TO_SYNC="1c21c8a"
+COMMIT_TO_SYNC="5436e90"
 
 .PHONY: all
 all: fetch-upstream-manifest apply-kustomize-patches delete-generated-helm-charts release-manifests ## Builds the manifests to publish with a release (alias to release-manifests)

--- a/helm/cluster-api-provider-cloud-director/values.yaml
+++ b/helm/cluster-api-provider-cloud-director/values.yaml
@@ -1,6 +1,6 @@
 image:
   name: quay.io/giantswarm/cluster-api-provider-cloud-director-vcd
-  tag: "1c21c8a"
+  tag: "5436e90"
 
 project:
   branch: ""


### PR DESCRIPTION
This PR brings the changes in this PR https://github.com/giantswarm/cluster-api-provider-cloud-director/pull/5
Basically the fix for `clusterctl move`. 

### Testing

- [ ] fresh install works
- [ ] upgrade from previous version works

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
- [ ] Update lastpass values if required.
