### PR TITLE
Don't build&push the container image here

### DIFF
--- a/hack/sync-version.sh
+++ b/hack/sync-version.sh
@@ -18,17 +18,12 @@ pushd "${REPO_NAME}"
 git checkout -d "${COMMIT_TO_SYNC}"
 
 # see https://github.com/vmware/cluster-api-provider-cloud-director/pull/350
-rm ./tools/*
+rm ./tools/* || true
 
 # install required binaries
 make kustomize controller-gen conversion
 
 make release-manifests
-
-# build and push a corresponding image
-make docker-build
-docker tag harbor-repo.vmware.com/vcloud/cluster-api-provider-cloud-director:main-branch quay.io/giantswarm/cluster-api-provider-cloud-director-vcd:${COMMIT_TO_SYNC}
-docker push quay.io/giantswarm/cluster-api-provider-cloud-director-vcd:${COMMIT_TO_SYNC}
 
 # remote cluster-api-provider-cloud-director from the stack
 popd


### PR DESCRIPTION
Let's not build and push image with this script (use retagger instead). Also if the tools dir was not present the script failed.

Signed-off-by: Jiri Kremser <jiri.kremser@gmail.com>