### PR TITLE
Add toleration for new control-plane taint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add toleration for new control-plane taint.
+
 ## [0.5.0] - 2023-04-04
 
 ### Added

--- a/helm/cluster-api-provider-cloud-director/templates/crd-install/crd-job.yaml
+++ b/helm/cluster-api-provider-cloud-director/templates/crd-install/crd-job.yaml
@@ -26,6 +26,8 @@ spec:
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        effect: NoSchedule
       containers:
       - name: kubectl
         image: "{{ .Values.crds.jobRegistry }}/giantswarm/docker-kubectl:latest"


### PR DESCRIPTION
This PR adds a toleration for the `node-role.kubernetes.io/control-plane` taint to resources that already have a toleration to the deprecated `node-role.kubernetes.io/master` taint.

Towards https://github.com/giantswarm/roadmap/issues/2468

### Testing

Description on how {APP-NAME} can be tested.

- [ ] fresh install works
- [ ] upgrade from previous version works

#### Other testing

Description of features to additionally test for {APP-NAME} installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
- [ ] Update lastpass values if required.
