### PR TITLE
Add the gh action that detects the drift in manifests

### DIFF
--- a/.github/workflows/check_generated.yaml
+++ b/.github/workflows/check_generated.yaml
@@ -1,0 +1,21 @@
+name: check generated yamls
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+
+jobs:
+  check:
+    name: check generated yamls
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3.1.0
+    - name: generate manifests
+      run: make all
+    - name: check no change
+      run: git diff --quiet --exit-code && [ -z "$(git status --porcelain)" ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add Service monitor cr.
+- :seedling: GH action that verifies if `make all` was run (drift detection).
 
 ## [0.6.1] - 2023-07-25
 

--- a/config/kustomize/kustomization.yaml
+++ b/config/kustomize/kustomization.yaml
@@ -7,7 +7,6 @@ resources:
 - input/infrastructure-components.yaml
 - resources/ciliumnetworkpolicy_capvcd-controller-manager.yaml
 - resources/networkpolicy_capvcd-controller-manager.yaml
-- input/infrastructure-components.yaml
 
 transformers:
 - patches/common-labels.yaml

--- a/helm/cluster-api-provider-cloud-director/templates/apps_v1_deployment_capvcd-controller-manager.yaml
+++ b/helm/cluster-api-provider-cloud-director/templates/apps_v1_deployment_capvcd-controller-manager.yaml
@@ -59,7 +59,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
               {{- with .Values.podSecurityContext }}
-              	{{- . | toYaml | nindent 12 }}
+                {{- . | toYaml | nindent 12 }}
               {{- end }}
           volumeMounts:
             - mountPath: /tmp/k8s-webhook-server/serving-certs


### PR DESCRIPTION
it will make the CI 🔴 , if the generated file was modified, but not the original or vice-versa (-> `make all` wasn't run). 

example:
- https://github.com/jkremser/cluster-api-provider-vsphere-app/pull/1
- https://github.com/jkremser/cluster-api-provider-vsphere-app/pull/2

edit: also fixing:

```
Error: accumulating resources: accumulation err='merging resources from 'input/infrastructure-components.yaml': may not add resource with an already registered id: Namespace.v1.[noGrp]/capvcd-system.[noNs]': must build at directory: '/home/runner/work/cluster-api-provider-cloud-director-app/cluster-api-provider-cloud-director-app/config/kustomize/input/infrastructure-components.yaml': file is not directory
```

the infra components are [defined twice](https://github.com/giantswarm/cluster-api-provider-cloud-director-app/pull/57/files#diff-12bdb52403497f6a3f9207ddcab47594256ccb9059c755e337c827f8a0742a9dR10) in the kustomization.