### PR TITLE
PSS (again)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- helm chart values `psps.install -> !global.podSecurityStandards.enforced`
+
 ## [0.7.1] - 2023-08-24
 
 ### Changed

--- a/hack/custom-patches.sh
+++ b/hack/custom-patches.sh
@@ -12,7 +12,7 @@ ${YQ} e '.spec.template.spec.securityContext.remove-this-key="'"
   {{- . | toYaml | nindent 8 }}
 {{- end }}
 "'" | .spec.template.spec.containers[].securityContext.remove-this-key="'"
-{{- with .Values.securityContext }}
+{{- with .Values.containerSecurityContext }}
   {{- . | toYaml | nindent 12 }}
 {{- end }}
 "'"' ${f} > ${f}.tmp

--- a/helm/cluster-api-provider-cloud-director/templates/apps_v1_deployment_capvcd-controller-manager.yaml
+++ b/helm/cluster-api-provider-cloud-director/templates/apps_v1_deployment_capvcd-controller-manager.yaml
@@ -58,7 +58,7 @@ spec:
               memory: '{{ .Values.resources.requests.memory }}'
           securityContext:
             allowPrivilegeEscalation: false
-              {{- with .Values.securityContext }}
+              {{- with .Values.containerSecurityContext }}
                 {{- . | toYaml | nindent 12 }}
               {{- end }}
           volumeMounts:

--- a/helm/cluster-api-provider-cloud-director/templates/crd-install/crd-job.yaml
+++ b/helm/cluster-api-provider-cloud-director/templates/crd-install/crd-job.yaml
@@ -44,7 +44,7 @@ spec:
           kubectl apply -f /data/ 2>&1
         securityContext:
           readOnlyRootFilesystem: true
-          {{- with .Values.securityContext }}
+          {{- with .Values.containerSecurityContext }}
             {{- . | toYaml | nindent 10 }}
           {{- end }}
         volumeMounts:

--- a/helm/cluster-api-provider-cloud-director/templates/crd-install/crd-psp.yaml
+++ b/helm/cluster-api-provider-cloud-director/templates/crd-install/crd-psp.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.crdInstall.enable }}
-{{- if .Values.psps.install }}
+{{- if not .Values.global.podSecurityStandards.enforced }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -35,5 +36,6 @@ spec:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: false
+{{- end }}
 {{- end }}
 {{- end }}

--- a/helm/cluster-api-provider-cloud-director/templates/crd-install/crd-rbac.yaml
+++ b/helm/cluster-api-provider-cloud-director/templates/crd-install/crd-rbac.yaml
@@ -29,7 +29,8 @@ rules:
   - delete
   - get
   - patch
-{{- if .Values.psps.install }}
+{{- if not .Values.global.podSecurityStandards.enforced }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 - apiGroups:
   - policy
   resources:
@@ -38,6 +39,7 @@ rules:
   - {{ include "crdInstall" . }}
   verbs:
   - use
+{{- end }}
 {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/cluster-api-provider-cloud-director/templates/psp/psp-rbac.yaml
+++ b/helm/cluster-api-provider-cloud-director/templates/psp/psp-rbac.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.psps.install }}
+{{- if not .Values.global.podSecurityStandards.enforced }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -29,4 +30,5 @@ roleRef:
   kind: ClusterRole
   name: capvcd-controller-manager-psp
   apiGroup: rbac.authorization.k8s.io
+{{- end }}
 {{- end }}

--- a/helm/cluster-api-provider-cloud-director/templates/psp/psp.yaml
+++ b/helm/cluster-api-provider-cloud-director/templates/psp/psp.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.psps.install }}
+{{- if not .Values.global.podSecurityStandards.enforced }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -29,4 +30,5 @@ spec:
   hostNetwork: false
   hostIPC: false
   hostPID: false
+{{- end }}
 {{- end }}

--- a/helm/cluster-api-provider-cloud-director/values.schema.json
+++ b/helm/cluster-api-provider-cloud-director/values.schema.json
@@ -32,11 +32,16 @@
                 }
             }
         },
-        "psps": {
+        "global": {
             "type": "object",
             "properties": {
-                "install": {
-                    "type": "boolean"
+                "podSecurityStandards": {
+                    "type": "object",
+                    "properties": {
+                        "enforced": {
+                            "type": "boolean"
+                        }
+                    }
                 }
             }
         },

--- a/helm/cluster-api-provider-cloud-director/values.yaml
+++ b/helm/cluster-api-provider-cloud-director/values.yaml
@@ -42,13 +42,15 @@ podSecurityContext:
     type: RuntimeDefault
 
 # Add seccomp to container security context
-securityContext:
+containerSecurityContext:
   allowPrivilegeEscalation: false
   capabilities:
     drop:
       - ALL
+  runAsNonRoot: true
   seccompProfile:
     type: RuntimeDefault
 
-psps:
-  install: true
+global:
+  podSecurityStandards:
+    enforced: false


### PR DESCRIPTION
the feature flag for PSP should be called `global.podSecurityStandards.enforced` also renaming `Values.securityContext` -> `Values.containerSecurityContext` to not confuse it with pod level security context

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
