### PR TITLE
gzip + base64 encode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use `gzip+base64` instead of `base64` for bootstrap data delivery to VM metadata.
+
+## [0.8.1] - 2024-09-19
+
+### Changed
+
+- Update netpol to allow traffic to coredns.
+
 ## [0.8.0] - 2024-04-04
 
 ### Added
@@ -177,7 +187,8 @@ were left as default then no action is required.
 - Initial chart implementation
 - Install CRDs via job
 
-[Unreleased]: https://github.com/giantswarm/cluster-api-provider-cloud-director-app/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/giantswarm/cluster-api-provider-cloud-director-app/compare/v0.8.1...HEAD
+[0.8.1]: https://github.com/giantswarm/cluster-api-provider-cloud-director-app/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/giantswarm/cluster-api-provider-cloud-director-app/compare/v0.7.2...v0.8.0
 [0.7.2]: https://github.com/giantswarm/cluster-api-provider-cloud-director-app/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/giantswarm/cluster-api-provider-cloud-director-app/compare/v0.7.0...v0.7.1

--- a/helm/cluster-api-provider-cloud-director/values.yaml
+++ b/helm/cluster-api-provider-cloud-director/values.yaml
@@ -1,6 +1,6 @@
 image:
   name: "gsoci.azurecr.io/giantswarm/cluster-api-provider-cloud-director-vcd"
-  tag: "b13658f5"
+  tag: "34209a55"
 
 project:
   branch: ""

--- a/helm/cluster-api-provider-cloud-director/values.yaml
+++ b/helm/cluster-api-provider-cloud-director/values.yaml
@@ -1,6 +1,6 @@
 image:
   name: "gsoci.azurecr.io/giantswarm/cluster-api-provider-cloud-director-vcd"
-  tag: "15b5577a"
+  tag: "f447f3af"
 
 project:
   branch: ""

--- a/helm/cluster-api-provider-cloud-director/values.yaml
+++ b/helm/cluster-api-provider-cloud-director/values.yaml
@@ -1,6 +1,6 @@
 image:
   name: "gsoci.azurecr.io/giantswarm/cluster-api-provider-cloud-director-vcd"
-  tag: "06f9f9c8"
+  tag: "b13658f5"
 
 project:
   branch: ""

--- a/helm/cluster-api-provider-cloud-director/values.yaml
+++ b/helm/cluster-api-provider-cloud-director/values.yaml
@@ -1,6 +1,6 @@
 image:
   name: "gsoci.azurecr.io/giantswarm/cluster-api-provider-cloud-director-vcd"
-  tag: "34209a55"
+  tag: "15b5577a"
 
 project:
   branch: ""


### PR DESCRIPTION
When using large bootstrapdata, the update metadata tasks fail because there is an (undocumented) 64KB limit on VM advanced fields in VCD.

This PR consumes https://github.com/giantswarm/cluster-api-provider-cloud-director/pull/18 which makes use of the `gzip+base64` encoding method instead of `base64` supported by [Flatcar](https://www.flatcar.org/docs/latest/installing/cloud/vmware/#defining-the-ignition-config-or-coreos-cloudinit-cloud-config-in-guestinfo). Compressing the data before encoding it allows it to stay under that limit.
