### PR TITLE
Added a Giant Swarm PolicyException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+ - Added a Giant Swarm PolicyException to allow the deployment to run.
+
 ## [0.8.3] - 2026-02-03
 
 ### Changed

--- a/helm/cluster-api-provider-cloud-director/templates/custom/gs-policy-exception.yaml
+++ b/helm/cluster-api-provider-cloud-director/templates/custom/gs-policy-exception.yaml
@@ -1,0 +1,24 @@
+{{- if .Capabilities.APIVersions.Has "policy.giantswarm.io/v1alpha1/PolicyException" }}
+apiVersion: policy.giantswarm.io/v1alpha1
+kind: PolicyException
+metadata:
+  labels:
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
+    app.kubernetes.io/name: '{{ .Chart.Name }}'
+    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
+    helm.sh/chart: '{{ .Chart.Name }}'
+  name: capvcd-controller-manager
+  namespace: policy-exceptions
+spec:
+  policies:
+  - disallow-capabilities-strict
+  - require-run-as-nonroot
+  - restrict-seccomp-strict
+  targets:
+  - kind: Deployment
+    names:
+    - capvcd-controller-manager
+    namespaces:
+    - {{ .Release.Namespace }}
+{{- end }}


### PR DESCRIPTION
Without this the latest release won't start:

```
% kubectl --context gerbil describe app --namespace giantswarm cluster-api-provider-cloud-director

...

request:

resource Deployment/giantswarm/capvcd-controller-manager was blocked due to the following policies

disallow-capabilities-strict:
  autogen-require-drop-all: 'validation failure: Containers must drop `ALL` capabilities.'
require-run-as-nonroot:
  autogen-run-as-non-root: 'validation error: Running as root is not allowed. Either
    the field spec.securityContext.runAsNonRoot must be set to `true`, or the fields
    spec.containers[*].securityContext.runAsNonRoot, spec.initContainers[*].securityContext.runAsNonRoot,
    and spec.ephemeralContainers[*].securityContext.runAsNonRoot must be set to `true`.
    rule autogen-run-as-non-root[0] failed at path /spec/template/spec/securityContext/runAsNonRoot/
    rule autogen-run-as-non-root[1] failed at path /spec/template/spec/containers/0/securityContext/runAsNonRoot/'
restrict-seccomp-strict:
  autogen-check-seccomp-strict: 'validation error: Use of custom Seccomp profiles
    is disallowed. The fields spec.securityContext.seccompProfile.type, spec.containers[*].securityContext.seccompProfile.type,
    spec.initContainers[*].securityContext.seccompProfile.type, and spec.ephemeralContainers[*].securityContext.seccompProfile.type
    must be set to `RuntimeDefault` or `Localhost`. rule autogen-check-seccomp-strict[0]
    failed at path /spec/template/spec/securityContext/seccompProfile/ rule autogen-check-seccomp-strict[1]
    failed at path /spec/template/spec/containers/0/securityContext/seccompProfile/'

    Status:  failed
  Version:   0.8.3
Events:      <none>
```

### Checklist

- [x] Update changelog in CHANGELOG.md.
