### PR TITLE
Wrap Cilium resources in conditional cluster capabilities check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Wrap Cilium resources in conditional cluster capabilities check.
+
 ## [0.8.4] - 2026-02-05
 
 ### Added

--- a/hack/wrap-with-conditional.sh
+++ b/hack/wrap-with-conditional.sh
@@ -8,7 +8,7 @@ cd "helm/cluster-api-provider-cloud-director/templates"
 
 for file in *_ciliumnetworkpolicy_*.yaml; do
     data=$(cat "${file}")
-    echo '{{- if .Values.ciliumNetworkPolicy.enabled }}' > "${file}"
+    echo '{{- if and (.Values.ciliumNetworkPolicy.enabled) (.Capabilities.APIVersions.Has "cilium.io/v2") }}' > "${file}"
     echo "${data}" >> "${file}"
     echo '{{- end }}' >> "${file}"
 done

--- a/helm/cluster-api-provider-cloud-director/templates/cilium.io_v2_ciliumnetworkpolicy_capvcd-controller-manager.yaml
+++ b/helm/cluster-api-provider-cloud-director/templates/cilium.io_v2_ciliumnetworkpolicy_capvcd-controller-manager.yaml
@@ -1,3 +1,4 @@
+{{- if and (.Values.ciliumNetworkPolicy.enabled) (.Capabilities.APIVersions.Has "cilium.io/v2") }}
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -23,3 +24,4 @@ spec:
   - fromEntities:
     - cluster
     - kube-apiserver
+{{- end }}


### PR DESCRIPTION
I'm not sure how this got dropped but it breaks app installation in vcluster clusters during mc-bootstrap runs

see https://tekton.ci.giantswarm.io/#/namespaces/mc-bootstrap/pipelineruns/pr-mc-bootstrap-1534-generate-mchd4qq?pipelineTask=generate-mc&step=generate-mc&view=logs

### Checklist

- [x] Update changelog in CHANGELOG.md.